### PR TITLE
More frequent imports

### DIFF
--- a/src/main/java/no/vebb/f1/importing/Importer.java
+++ b/src/main/java/no/vebb/f1/importing/Importer.java
@@ -39,7 +39,7 @@ public class Importer {
 		this.db = db;
 	}
 
-	@Scheduled(fixedRate = 3600000, initialDelay = 5000)
+	@Scheduled(fixedRate = 600000, initialDelay = 5000)
 	@Transactional
 	public void importData() {
 		logger.info("Starting import of data to database");


### PR DESCRIPTION
Imports results every 10 minutes instead of every hour.
Rolls back if standings where not new when race results are new. This is to ensure that race results and standings are always in sync.
